### PR TITLE
fix(ui): フォルダ展開時の矢印の向きを修正

### DIFF
--- a/src/core/folder-mode/assets/folder-mode.css
+++ b/src/core/folder-mode/assets/folder-mode.css
@@ -167,11 +167,12 @@ html, body {
   align-items: center;
   justify-content: center;
   color: var(--sidebar-text-muted);
+  transform: rotate(90deg);  /* expanded state: down arrow */
   transition: transform 0.1s;
 }
 
 .vimd-tree-chevron.collapsed {
-  transform: rotate(-90deg);
+  transform: rotate(0deg);  /* collapsed state: right arrow */
 }
 
 /* Tree children (nested items) */


### PR DESCRIPTION
## Summary

- フォルダ展開時の矢印アイコン（chevron）の向きを修正
- 開いた状態の矢印を上向き (∧) から下向き (∨) に変更
- 一般的なファイルエクスプローラーと同じ挙動に統一

## Changes

| 状態 | 修正前 | 修正後 |
|------|--------|--------|
| 閉じた状態 | 右向き (>) | 右向き (>) |
| 開いた状態 | 上向き (∧) | 下向き (∨) |

## Test plan

- [x] フォルダを閉じた状態で矢印が右向き (>) になることを確認
- [x] フォルダをクリックして開いた状態で矢印が下向き (∨) になることを確認
- [x] 矢印の回転アニメーション（0.1秒）が正常に動作することを確認

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)